### PR TITLE
Add GitHub Actions workflow for GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy-pages-on-tag.yml
+++ b/.github/workflows/deploy-pages-on-tag.yml
@@ -1,0 +1,53 @@
+name: Deploy GitHub Pages on Tag
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+        env:
+          NODE_ENV: production
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: ./dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,9 @@ import { defineConfig } from "vite";
 
 export default defineConfig(() => {
   return {
+    // Use repository sub-path for GitHub Pages when building for production.
+    // This makes the app work at https://deadronos.github.io/NanoBotsIdle/
+    base: process.env.NODE_ENV === 'production' ? '/NanoBotsIdle/' : '/',
     server: {
       port: 3000,
       host: "0.0.0.0",


### PR DESCRIPTION
Implement a GitHub Actions workflow to automate deployment to GitHub Pages upon tagging a release. Adjust the build configuration to support the repository sub-path for production.