### PR TITLE
Add visibility-aware meshing priority helper

### DIFF
--- a/src/components/world/VoxelLayerMeshed.tsx
+++ b/src/components/world/VoxelLayerMeshed.tsx
@@ -4,7 +4,11 @@ import React, { useCallback, useEffect, useMemo, useRef } from "react";
 import { useConfig } from "../../config/useConfig";
 import { playerChunk, playerPosition } from "../../engine/playerState";
 import { applyLodGeometry } from "../../render/lodGeometry";
-import { applyChunkVisibility, createLodThresholds } from "../../render/lodUtils";
+import {
+  applyChunkVisibility,
+  createLodThresholds,
+  isChunkVisible as isChunkVisibleForPriority,
+} from "../../render/lodUtils";
 import { applyVoxelEdits, resetVoxelEdits } from "../../sim/collision";
 import { getSurfaceHeightCore } from "../../sim/terrain-core";
 import { getSimBridge } from "../../simBridge/simBridge";
@@ -29,6 +33,11 @@ export const VoxelLayerMeshed: React.FC<{
   const { camera } = useThree();
 
   const lodThresholds = useMemo(() => createLodThresholds(chunkSize), [chunkSize]);
+  const isChunkVisible = useCallback(
+    (coord: { cx: number; cy: number; cz: number }) =>
+      isChunkVisibleForPriority(coord, chunkSize, camera, lodThresholds),
+    [camera, chunkSize, lodThresholds],
+  );
 
   const handleSchedulerChange = useCallback(() => {
     // Clear activeChunks when scheduler is recreated (e.g., when actualSeed arrives)
@@ -44,6 +53,7 @@ export const VoxelLayerMeshed: React.FC<{
       waterLevel: cfg.terrain.waterLevel,
       seed,
       onSchedulerChange: handleSchedulerChange,
+      isChunkVisible,
     });
 
   const debugCfg = cfg.render.voxels.debugCompare;

--- a/src/components/world/useMeshedChunks.ts
+++ b/src/components/world/useMeshedChunks.ts
@@ -33,8 +33,10 @@ export const useMeshedChunks = (options: {
   waterLevel: number;
   seed?: number;
   onSchedulerChange?: () => void;
+  isChunkVisible?: (coord: { cx: number; cy: number; cz: number }) => boolean;
 }) => {
-  const { chunkSize, prestigeLevel, waterLevel, seed, onSchedulerChange } = options;
+  const { chunkSize, prestigeLevel, waterLevel, seed, onSchedulerChange, isChunkVisible } =
+    options;
 
   const focusChunkRef = useRef<{ cx: number; cy: number; cz: number }>({ cx: 0, cy: 0, cz: 0 });
   const reprioritizeTimeoutRef = useRef<number | null>(null);
@@ -249,6 +251,7 @@ export const useMeshedChunks = (options: {
       maxInFlight: config.meshing.maxInFlight,
       maxQueueSize: config.meshing.maxQueueSize,
       getPriority: priorityFromFocus,
+      isVisible: isChunkVisible,
     });
 
     schedulerRef.current = scheduler;
@@ -268,6 +271,7 @@ export const useMeshedChunks = (options: {
     applyMeshResult,
     chunkSize,
     disposeAllMeshes,
+    isChunkVisible,
     onSchedulerChange,
     prestigeLevel,
     seed,

--- a/src/render/lodUtils.ts
+++ b/src/render/lodUtils.ts
@@ -46,6 +46,26 @@ const distanceSqToPoint = (
   return dx * dx + dy * dy + dz * dz;
 };
 
+export const isChunkVisible = (
+  coord: { cx: number; cy: number; cz: number },
+  chunkSize: number,
+  camera: Camera,
+  thresholds: LodThresholds,
+): boolean => {
+  const center = {
+    x: (coord.cx + 0.5) * chunkSize,
+    y: (coord.cy + 0.5) * chunkSize,
+    z: (coord.cz + 0.5) * chunkSize,
+  };
+  const radius = (Math.sqrt(3) * chunkSize) / 2;
+  const distanceSq = distanceSqToPoint(camera.position, center);
+  const lod = selectLodLevel(distanceSq, thresholds);
+  if (lod === "hidden") return false;
+
+  const frustum = getFrustumFromCamera(camera);
+  return isSphereVisible(frustum, center, radius);
+};
+
 export const applyChunkVisibility = (
   meshes: Iterable<Object3D>,
   camera: Camera,

--- a/tests/chunk-visibility.test.ts
+++ b/tests/chunk-visibility.test.ts
@@ -1,0 +1,23 @@
+import { PerspectiveCamera } from "three";
+import { describe, expect, it } from "vitest";
+
+import { createLodThresholds, isChunkVisible } from "../src/render/lodUtils";
+
+describe("isChunkVisible", () => {
+  it("respects frustum visibility and hide-distance thresholds", () => {
+    const camera = new PerspectiveCamera(60, 1, 0.1, 500);
+    camera.position.set(0, 0, 0);
+    camera.lookAt(0, 0, -1);
+    camera.updateProjectionMatrix();
+    camera.updateMatrixWorld();
+
+    const thresholds = createLodThresholds(16, {
+      lowDistanceMultiplier: 2,
+      hideDistanceMultiplier: 3,
+    });
+
+    expect(isChunkVisible({ cx: 0, cy: 0, cz: -1 }, 16, camera, thresholds)).toBe(true);
+    expect(isChunkVisible({ cx: 0, cy: 0, cz: -5 }, 16, camera, thresholds)).toBe(false);
+    expect(isChunkVisible({ cx: 5, cy: 0, cz: -1 }, 16, camera, thresholds)).toBe(false);
+  });
+});


### PR DESCRIPTION
### Motivation
- Reduce meshing worker overload and frame stalls by prioritizing chunks not only by distance but also by camera visibility.
- Provide a fast, deterministic check that combines LOD distance thresholds with frustum culling for priority decisions.
- Surface visibility info to the meshing scheduler so visible chunks are treated as higher priority during overload.

### Description
- Add `isChunkVisible` helper in `src/render/lodUtils.ts` that computes a chunk center/radius, applies LOD distance thresholds via `selectLodLevel`, and performs frustum culling using `getFrustumFromCamera` + `isSphereVisible`.
- Wire visibility-aware priority into the meshing pipeline by passing the `isVisible` provider from `VoxelLayerMeshed` through `useMeshedChunks` into `MeshingScheduler`.
- Add unit test `tests/chunk-visibility.test.ts` to validate distance/hide thresholds and frustum-based visibility behavior.

### Testing
- Ran `npm test -- chunk-visibility.test.ts` (Vitest) and the new test passed.
- No other automated test suites were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69656cc038cc832abe423c64f2960cd8)